### PR TITLE
OPManager: fix preview

### DIFF
--- a/src/main/kotlin/de/shyim/idea1password/OPManager.kt
+++ b/src/main/kotlin/de/shyim/idea1password/OPManager.kt
@@ -12,7 +12,7 @@ import java.io.File
 
 object OPManager {
     fun preview(project: Project, srcFile: File): String {
-        val commandLine = GeneralCommandLine("op", "inject")
+        val commandLine = GeneralCommandLine("op", "inject", "--in-file")
         commandLine.withInput(File(srcFile.path))
         appendConfig(project, commandLine, false)
 


### PR DESCRIPTION
add '--in-file' cli parameter when building command line

the issue is described in #8 