### PR TITLE
add $1Password$ run config macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@
 - Preview your Secrets: You can right-click any file or editor to see the preview of your secrets
 - Generate new Passwords: You can generate using the Generate menu new secrets and insert the reference to it
 - Choose a Secret from your Vault: You can search in your Vault and insert the reference to the item
-- 
+- Pass secrets as command line arguments into Run Configurations with macros.
 <!-- Plugin description end -->

--- a/src/main/kotlin/de/shyim/idea1password/OPManager.kt
+++ b/src/main/kotlin/de/shyim/idea1password/OPManager.kt
@@ -42,7 +42,13 @@ object OPManager {
         for (i in 0 until json.length()) {
             val item = json.getJSONObject(i)
 
-            list.add(VaultListItem(item.getString("id"), item.getString("title"), item.getJSONObject("vault").getString("name")))
+            list.add(
+                VaultListItem(
+                    item.getString("id"),
+                    item.getString("title"),
+                    item.getJSONObject("vault").getString("name")
+                )
+            )
         }
 
         return list
@@ -51,7 +57,6 @@ object OPManager {
     fun getItem(project: Project, id: String): VaultItem {
         val commandLine = GeneralCommandLine("op", "item", "get", id, "--format", "json")
         appendConfig(project, commandLine)
-
         val handler = CapturingProcessHandler(commandLine).runProcess(30000)
 
         if (handler.exitCode != 0) {
@@ -107,6 +112,19 @@ object OPManager {
         throw InvalidJSONResponseFromOP("Could not find reference in op command")
     }
 
+    fun readPath(project: Project?, reference: String): String {
+        val commandLine = GeneralCommandLine("op", "read", "-n", reference)
+        val handler = CapturingProcessHandler(commandLine).runProcess(30000)
+        if (project != null) {
+            appendConfig(project, commandLine, false)
+        }
+
+        if (handler.exitCode != 0) {
+            throw CommandExecutionFailed(handler.stderr)
+        }
+        return handler.stdout
+    }
+
     private fun appendConfig(project: Project, cmd: GeneralCommandLine, addVault: Boolean = true) {
         val settings = OnePasswordSettings.getInstance(project)
 
@@ -121,5 +139,5 @@ object OPManager {
     }
 }
 
-class CommandExecutionFailed(message: String): Exception(message)
-class InvalidJSONResponseFromOP(message: String): Exception(message)
+class CommandExecutionFailed(message: String) : Exception(message)
+class InvalidJSONResponseFromOP(message: String) : Exception(message)

--- a/src/main/kotlin/de/shyim/idea1password/OnePasswordMacro.kt
+++ b/src/main/kotlin/de/shyim/idea1password/OnePasswordMacro.kt
@@ -1,0 +1,29 @@
+package de.shyim.idea1password
+
+import com.intellij.ide.macro.Macro
+import com.intellij.ide.macro.MacroWithParams
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.DataContext
+
+class OnePasswordMacro : Macro(), MacroWithParams {
+    override fun getName(): String {
+        return "1Password"
+    }
+
+    override fun getDescription(): String {
+        return OnePassword.message("macroDescription")
+    }
+
+    override fun expand(dataContext: DataContext, vararg args: String): String? {
+        return if (args.size == 1) {
+            // It might be a bug but in the Java application run config,
+            // we get access to the Project from the "Program Args" but not from VM Options
+            val project = CommonDataKeys.PROJECT.getData(dataContext)
+            OPManager.readPath(project, args[0])
+        } else null;
+    }
+
+    override fun expand(dataContext: DataContext): String? {
+        return null
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -25,5 +25,7 @@
                 provider="de.shyim.idea1password.OnePasswordConfigurableProvider"/>
 
         <projectService serviceImplementation="de.shyim.idea1password.OnePasswordSettings"/>
+        <macro implementation="de.shyim.idea1password.OnePasswordMacro"/>
     </extensions>
+
 </idea-plugin>

--- a/src/main/resources/messages/OnePassword.properties
+++ b/src/main/resources/messages/OnePassword.properties
@@ -1,2 +1,3 @@
 name=1Password
 previewAction=Preview File With Resolved Secrets
+macroDescription=Read a value out of 1Password. Pass the secret reference as a param, ex: $1Password(op://app-prod/db/password)$"


### PR DESCRIPTION
Add a new [macro](https://www.jetbrains.com/help/idea/built-in-macros.html) for Run Configs and External Tools.

<img width="828" alt="Screenshot 2023-09-15 at 15 23 29" src="https://github.com/shyim/idea-1password/assets/315988/86233ca2-457f-4f00-99b6-4fe0bead155a">


<img width="910" alt="Screenshot 2023-09-15 at 15 25 59" src="https://github.com/shyim/idea-1password/assets/315988/4ae2fd6f-717c-4d03-b514-9a096af94f4e">

Basically you can pass `$1Passsword(op://path-to-secret)` into several of the fields when running an applications, such as VM options or command line arguments.

This is my first attempt at Kotlin, so I might have gotten some things wrong, I just tried to copy existing patterns in the code.